### PR TITLE
strip leading v in input versions

### DIFF
--- a/.github/workflows/update-zimfarm-offliner-definition.yaml
+++ b/.github/workflows/update-zimfarm-offliner-definition.yaml
@@ -31,6 +31,7 @@ jobs:
           set -euo pipefail
 
           version='${{ inputs.version }}'
+          version="${version#v}"
           offliner='${{ inputs.offliner }}'
           ci_secret='${{ secrets.zimfarm_ci_secret }}'
           zimfarm_url='${{ matrix.zimfarm_url }}'


### PR DESCRIPTION
# Changes
- strip leading `v` in input version passed to update-zimfarm-offliner-defintions CI job