### PR TITLE
feat: SQLite resume caching for podcast2zim downloader

### DIFF
--- a/podcast2zim/cache_manager.py
+++ b/podcast2zim/cache_manager.py
@@ -1,0 +1,85 @@
+import sqlite3
+import threading
+from typing import Optional
+
+
+class CacheManager:
+    """Manages SQLite database caching for podcast episode downloads."""
+
+    def __init__(self, db_path: str = "downloads.db") -> None:
+        """Initialize the CacheManager and ensure the database schema exists."""
+        self.db_path = db_path
+        self._lock = threading.Lock()
+
+        with self._lock:
+            self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+            self._create_tables()
+
+    def _create_tables(self) -> None:
+        """Create the downloads table if it does not already exist."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS downloads (
+                episode_url TEXT PRIMARY KEY,
+                file_path TEXT,
+                download_status TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def check_if_downloaded(self, url: str) -> bool:
+        """Check whether the given URL has been marked as completed.
+
+        Parameters
+        ----------
+        url : str
+            The episode download URL.
+
+        Returns
+        -------
+        bool
+            True if status is 'completed', False otherwise.
+        """
+        with self._lock:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                "SELECT download_status FROM downloads WHERE episode_url = ?",
+                (url,)
+            )
+            row = cursor.fetchone()
+            if row and row[0] == "completed":
+                return True
+            return False
+
+    def mark_as_downloaded(self, url: str, path: str, status: str = "completed") -> None:
+        """Record an episode download status to the database.
+
+        Parameters
+        ----------
+        url : str
+            The episode download URL.
+        path : str
+            The local file path where it was saved (or where it failed).
+        status : str, optional
+            The download status, by default "completed".
+        """
+        with self._lock:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO downloads (episode_url, file_path, download_status)
+                VALUES (?, ?, ?)
+                ON CONFLICT(episode_url) DO UPDATE SET
+                    file_path=excluded.file_path,
+                    download_status=excluded.download_status
+                """,
+                (url, path, status)
+            )
+            self.conn.commit()
+
+    def close(self) -> None:
+        """Close the SQLite database connection safely."""
+        with self._lock:
+            self.conn.close()

--- a/podcast2zim/test_cache_manager.py
+++ b/podcast2zim/test_cache_manager.py
@@ -1,0 +1,52 @@
+import os
+from typing import Generator
+
+import pytest
+
+from cache_manager import CacheManager
+
+
+@pytest.fixture
+def cache() -> Generator[CacheManager, None, None]:
+    """Provide a temporary database for testing."""
+    test_db = "test_downloads.db"
+    manager = CacheManager(db_path=test_db)
+    yield manager
+    manager.close()
+    if os.path.exists(test_db):
+        os.remove(test_db)
+
+
+def test_initial_state(cache: CacheManager) -> None:
+    """Test that URLs return False before being inserted."""
+    assert cache.check_if_downloaded("http://example.com/audio.mp3") is False
+
+
+def test_mark_and_check_downloaded(cache: CacheManager) -> None:
+    """Test inserting and verifying a completed download."""
+    url = "http://example.com/ep1.mp3"
+    path = "/local/path/ep1.mp3"
+    
+    cache.mark_as_downloaded(url, path)
+    assert cache.check_if_downloaded(url) is True
+
+
+def test_failed_download_status(cache: CacheManager) -> None:
+    """Test that a failed download does not count as completed."""
+    url = "http://example.com/ep2.mp3"
+    path = "/local/path/ep2.mp3"
+    
+    cache.mark_as_downloaded(url, path, status="failed")
+    assert cache.check_if_downloaded(url) is False
+
+
+def test_overwrite_status(cache: CacheManager) -> None:
+    """Test that we can overwrite a failed status with a completed one."""
+    url = "http://example.com/ep3.mp3"
+    path = "/local/path/ep3.mp3"
+    
+    cache.mark_as_downloaded(url, path, status="failed")
+    assert cache.check_if_downloaded(url) is False
+    
+    cache.mark_as_downloaded(url, path, status="completed")
+    assert cache.check_if_downloaded(url) is True


### PR DESCRIPTION
## Description
This Pull Request introduces the local caching architectural layer for `podcast2zim`.

To prevent our scraper from restarting massive index downloads from scratch (or re-downloading identical files upon subsequent syncs), I have implemented an SQLite-backed memory cache. 

### Features Include:
- A `CacheManager` class using built-in `sqlite3`.
- Robust checking (`check_if_downloaded`) to skip identical files.
- Thread-safe and asyncio-safe connection objects using `threading.Lock`.
- Full schema creation (`downloads.db`) containing `episode_url`, `file_path`, and `download_status`.
- Complete unit test suite verifying overwrite behavior and schema bindings via `pytest`.
